### PR TITLE
ci(renovate): enforce 3-day minimum release age for npm packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,9 +11,7 @@
   ],
   "packageRules": [
     {
-      "matchFileNames": [
-        "**/package.json"
-      ],
+      "matchFileNames": ["**/package.json"],
       "matchDepTypes": [
         "dependencies",
         "devDependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -6,11 +6,14 @@
     ":configMigration",
     "group:allNonMajor",
     "schedule:daily",
-    ":maintainLockFilesWeekly"
+    ":maintainLockFilesWeekly",
+    "security:minimumReleaseAgeNpm"
   ],
   "packageRules": [
     {
-      "matchFileNames": ["**/package.json"],
+      "matchFileNames": [
+        "**/package.json"
+      ],
       "matchDepTypes": [
         "dependencies",
         "devDependencies",


### PR DESCRIPTION
Extend the Renovate config with the official `security:minimumReleaseAgeNpm`
preset so that Renovate waits 3 days after publication before creating PRs
for any npm/pnpm dependency.

This adds a buffer against unpublished or freshly-broken releases (e.g.
malicious packages, npm unpublish window, transient registry/lockfile
resolution issues).

Mirrors SAP/e-mobility-charging-stations-simulator@191033595c4507db7a06720a44293f84d8e913c8.